### PR TITLE
Refactor revive and knockback logic for enemies

### DIFF
--- a/Assets/Data/Scripts/Enemies/1/NinjaController.cs
+++ b/Assets/Data/Scripts/Enemies/1/NinjaController.cs
@@ -11,13 +11,10 @@ public class NinjaController : MonoBehaviour
         [SerializeField] private float attackRange = 10f;
         [SerializeField] private float moveRange = 15f;
         [SerializeField] private float attackCoolDown = 2f;
-        [SerializeField] private float reviveCoolDown = 1.5f;
         [SerializeField] private float moveSpeed = 2f;
         [SerializeField] private Transform startPoint;
         [SerializeField] private Rigidbody2D rb;
-    
-        private bool isFacingRight = true;
-        private bool isReviving = false;
+        
         private Transform player;
         private Animator anim;
         private float cooldownTimer = Mathf.Infinity;
@@ -35,7 +32,7 @@ public class NinjaController : MonoBehaviour
         {
             if (enemyHealth.currentHealth <= 0) return;
             if (player == null) return;
-            if (isReviving) return;
+            if (enemyHealth.isReviving) return;
     
             cooldownTimer += Time.deltaTime;
             
@@ -102,39 +99,7 @@ public class NinjaController : MonoBehaviour
                     break;
             }
         }
-        public void BeAttack(float distance, float duration)
-        {
-            StartCoroutine(SmoothBeAttackMove(distance, duration));
-        }
-
-        private IEnumerator SmoothBeAttackMove(float distance, float duration)
-        {
-            float elapsed = 0f;
-            Vector2 startPos = rb.position;
-            int direction = isFacingRight ? -1 : 1;
-            Vector2 targetPos = startPos + new Vector2(direction *  distance, 0f);
-
-            while (elapsed < duration)
-            {
-                float t = elapsed / duration;
-                rb.MovePosition(Vector2.Lerp(startPos, targetPos, t));
-                elapsed += Time.deltaTime;
-                yield return null;
-            }
-
-            rb.MovePosition(targetPos); // đảm bảo tới đúng vị trí cuối
-        }
-        public void Revive()
-        {
-            StartCoroutine(ReviveCooldown());
-        }
-
-        private IEnumerator ReviveCooldown()
-        {
-            isReviving = true;
-            yield return new WaitForSeconds(reviveCoolDown);
-            isReviving = false;
-        }
+        
 
         private void Attack()
         {
@@ -150,12 +115,10 @@ public class NinjaController : MonoBehaviour
             if (player.position.x > transform.position.x)
             {
                 transform.localScale = new Vector3(-1, 1, 1);
-                isFacingRight = true;
             }
             else
             {
                 transform.localScale = new Vector3(1, 1, 1);
-                isFacingRight = false;
             }
         }
 
@@ -166,12 +129,10 @@ public class NinjaController : MonoBehaviour
             if (targetPosition.x > transform.position.x)
             {
                 transform.localScale = new Vector3(-1, 1, 1);
-                isFacingRight = true;
             }
             else
             {
                 transform.localScale = new Vector3(1, 1, 1);
-                isFacingRight = false;
             }
         }
 

--- a/Assets/Scenes/ScenesTest/Player.unity
+++ b/Assets/Scenes/ScenesTest/Player.unity
@@ -445,8 +445,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   startingHealth: 100
-  ninjaController: {fileID: 731275782}
   enemyObj: {fileID: 1866618443}
+  reviveCoolDown: 2
   isDead: 0
 --- !u!61 &731275780
 BoxCollider2D:
@@ -535,7 +535,6 @@ MonoBehaviour:
   attackRange: 1
   moveRange: 3
   attackCoolDown: 2
-  reviveCoolDown: 2
   moveSpeed: 2
   startPoint: {fileID: 2071712589}
   rb: {fileID: 731275781}


### PR DESCRIPTION
Moved revive and knockback (BeAttack) logic from NinjaController to EnemyHealth for better encapsulation and reusability. EnemyHealth now manages its own facing direction, revive cooldown, and knockback behavior. Updated scene and script references accordingly.