### PR TITLE
Add parry and health mechanics to player scripts

### DIFF
--- a/Assets/Data/Scripts/Player/PlayerController.cs
+++ b/Assets/Data/Scripts/Player/PlayerController.cs
@@ -56,6 +56,7 @@ public class PlayerController : MonoBehaviour
         UpdateAnimation();
         CheckIfWallSliding();
         CheckAttack();
+        CheckIfParrying();
     }
 
     void FixedUpdate()
@@ -66,12 +67,19 @@ public class PlayerController : MonoBehaviour
     private IEnumerator ParryCoroutine()
     {
         isParrying = true;
-        canMove = false;
-        playerRigidbody.velocity = new Vector2(0f, playerRigidbody.velocity.y);
         playerAnimator.SetTrigger("IsParry");
         yield return new WaitForSeconds(parryDuration);
         isParrying = false;
-        canMove = true;
+    }
+
+    private void CheckIfParrying()
+    {
+        if (isParrying)
+        {
+            canMove = false;
+            playerRigidbody.velocity = new Vector2(0f, playerRigidbody.velocity.y);
+        }
+        else canMove = true;
     }
 
     

--- a/Assets/Data/Scripts/Player/PlayerHealth.cs
+++ b/Assets/Data/Scripts/Player/PlayerHealth.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 public class PlayerHealth : MonoBehaviour
 {
     [SerializeField] public float startHealth;
+    [SerializeField] private float numberOfHearts;
     [SerializeField] private GameManagers gameManager;
     public float currentHeath {get; private set;}
 
@@ -23,7 +24,7 @@ public class PlayerHealth : MonoBehaviour
     {
         if (Input.GetKeyDown(KeyCode.Q) && !isDead)
         {
-            TakeDamage(10);
+            TakeHealth(100);
         }
     }
 
@@ -34,6 +35,17 @@ public class PlayerHealth : MonoBehaviour
         if (currentHeath <= 0 && !isDead)
         {
             StartCoroutine(HandleDeathSequence());
+        }
+        Debug.Log(currentHeath);
+    }
+    
+    private void TakeHealth(float _health)
+    {
+        if(isDead) return;
+        if (numberOfHearts > 0)
+        {
+            currentHeath = Mathf.Clamp(currentHeath + _health, 0, startHealth);
+            numberOfHearts--;
         }
         Debug.Log(currentHeath);
     }

--- a/Assets/Scenes/ScenesTest/Player.unity
+++ b/Assets/Scenes/ScenesTest/Player.unity
@@ -5590,6 +5590,10 @@ PrefabInstance:
       propertyPath: gameManager
       value: 
       objectReference: {fileID: 585965212}
+    - target: {fileID: 813382023633947433, guid: 69486438bf6d12747904d49daa0f994a, type: 3}
+      propertyPath: numberOfHearts
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 985928331690890858, guid: 69486438bf6d12747904d49daa0f994a, type: 3}
       propertyPath: m_Sprite
       value: 
@@ -5955,7 +5959,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7454648442923109096, guid: 8b25736cf2bfd104e9feb23743a5b3a4, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -87
+      value: -112.9
       objectReference: {fileID: 0}
     - target: {fileID: 7454648442923109096, guid: 8b25736cf2bfd104e9feb23743a5b3a4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/Assets/Unity Down/UI/9 Other/3 Skill icons/Skillicon7_16.png.meta
+++ b/Assets/Unity Down/UI/9 Other/3 Skill icons/Skillicon7_16.png.meta
@@ -34,7 +34,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -82,6 +82,19 @@ TextureImporter:
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3
     buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1


### PR DESCRIPTION
Introduced a parry state in PlayerController with movement lock during parry and refactored movement logic. PlayerHealth now supports a heart-based health system, including a TakeHealth method and numberOfHearts field. Updated Player.unity to set numberOfHearts and adjusted UI element position. Modified Skillicon7_16.png.meta to change filter mode and add Android platform settings.